### PR TITLE
Re-label Abort dialog button to Cancel

### DIFF
--- a/octoprint_PrintJobHistory/templates/PrintJobHistory_tab_dialogs.jinja2
+++ b/octoprint_PrintJobHistory/templates/PrintJobHistory_tab_dialogs.jinja2
@@ -277,7 +277,7 @@
                         <button type="button" class="btn btn-danger" data-bind="click: printJobEditDialog.deletePrintJobItem" >Delete Print Job</button>
                     </span>
                     <span class="span6 text-right">
-                        <button class="btn " data-bind="click: printJobEditDialog.abortPrintJobItem" style="text-align:right">Abort</button>
+                        <button class="btn " data-bind="click: printJobEditDialog.abortPrintJobItem" style="text-align:right">Cancel</button>
                         <button class="btn btn-primary" data-bind="click: printJobEditDialog.savePrintJobItem" style="text-align:right">Save</button>
                     </span>
                 </div>


### PR DESCRIPTION
Just a minor suggestion. Word Abort sounds like something will be interrupted. Cancel is more appropriate for closing a dialog window.