### PR TITLE
Reactor thumbnail extraction from metadata

### DIFF
--- a/octoprint_PrintJobHistory/CameraManager.py
+++ b/octoprint_PrintJobHistory/CameraManager.py
@@ -197,41 +197,42 @@ class CameraManager(object):
 		thread.start()
 
 
-	def takePluginThumbnail(self, snapshotFilename, printJobFilename, pluginFolder, extension = ".gcode"):
+	def takePluginThumbnail(self, snapshotFilename, thumbnailLocation):
 		if str(snapshotFilename).endswith(".jpg"):
 			snapshotFilename = self._snapshotStoragePath + "/" + snapshotFilename
 		else:
 			snapshotFilename = self._snapshotStoragePath + "/" + snapshotFilename + ".jpg"
 
-		if str(printJobFilename).endswith(extension):
-			printJobFilename = printJobFilename[0:len(printJobFilename)-len(extension)]
+		# clear timestamp in path
+		thumbnailLocation = thumbnailLocation.split("?", 1)[0]
 
-		thumnailLocation = self._pluginDataBaseFolder + "/../" + pluginFolder + "/" + printJobFilename + ".png"
-		if os.path.isfile(thumnailLocation):
+		# url path in format plugin/{plugin_folder}/thumbnail/{image_path}
+		splitPath = thumbnailLocation.split("/", 3)
+
+		if (len(splitPath) != 4):
+			self._logger.warning("Can not split thumbnail path '" + thumbnailLocation + "'")
+			return
+
+		pluginFolder = splitPath[1]
+		thumbnailName = splitPath[3]
+
+		thumbnailLocation = self._pluginDataBaseFolder + "/../" + pluginFolder + "/" + thumbnailName
+
+		if os.path.isfile(thumbnailLocation):
 			# Convert png to jpg and save in printjobhistory storage
 
-			self._logger.info("Try converting thumbnail '" + thumnailLocation + "' to '" + snapshotFilename + "'")
+			self._logger.info("Try converting thumbnail '" + thumbnailLocation + "' to '" + snapshotFilename + "'")
 
-			im = Image.open(thumnailLocation)
+			im = Image.open(thumbnailLocation)
 			rgb_im = im.convert('RGB')
 			rgb_im.save(snapshotFilename)
 
 			self._logger.info("Converting successfull!")
-			pass
 
 		else:
-			self._logger.warning("Thumbnail doesn't exists in: '"+thumnailLocation+"'")
+			self._logger.warning("Thumbnail doesn't exists in: '"+thumbnailLocation+"'")
 
-
-
-	def takeUltimakerPackageThumbnailAsync(self, snapshotFilename, printJobFilename):
-		pluginFolder = "UltimakerFormatPackage"
-		thread = threading.Thread(name='TakeUltimakerThumbnail', target=self.takePluginThumbnail, args=(snapshotFilename,printJobFilename,pluginFolder,))
-		thread.daemon = True
-		thread.start()
-
-	def takePrusaSlicerThumbnailAsync(self, snapshotFilename, printJobFilename):
-		pluginFolder = "prusaslicerthumbnails"
-		thread = threading.Thread(name='TakePrusaSlicerThumbnail', target=self.takePluginThumbnail, args=(snapshotFilename,printJobFilename,pluginFolder,))
+	def takeThumbnailAsync(self, snapshotFilename, thumbnailLocation):
+		thread = threading.Thread(name='TakeThumbnail', target=self.takePluginThumbnail, args=(snapshotFilename,thumbnailLocation))
 		thread.daemon = True
 		thread.start()

--- a/octoprint_PrintJobHistory/__init__.py
+++ b/octoprint_PrintJobHistory/__init__.py
@@ -46,10 +46,6 @@ class PrintJobHistoryPlugin(
 		self._filamentManagerPluginImplementationState = None
 		self._displayLayerProgressPluginImplementation = None
 		self._displayLayerProgressPluginImplementationState = None
-		self._ultimakerFormatPluginImplementation = None
-		self._ultimakerFormatPluginImplementationState = None
-		self._prusaSlicerThumbnailsPluginImplementation = None
-		self._prusaSlicerThumbnailsPluginImplementationState = None
 
 		pluginDataBaseFolder = self.get_plugin_data_folder()
 
@@ -102,20 +98,10 @@ class PrintJobHistoryPlugin(
 		self._displayLayerProgressPluginImplementationState  = pluginInfo[0]
 		self._displayLayerProgressPluginImplementation = pluginInfo[1]
 
-		pluginInfo = self._getPluginInformation("UltimakerFormatPackage")
-		self._ultimakerFormatPluginImplementationState  = pluginInfo[0]
-		self._ultimakerFormatPluginImplementation = pluginInfo[1]
-
-		pluginInfo = self._getPluginInformation("prusaslicerthumbnails")
-		self._prusaSlicerThumbnailsPluginImplementationState  = pluginInfo[0]
-		self._prusaSlicerThumbnailsPluginImplementation = pluginInfo[1]
-
 		self._logger.info("Plugin-State: "
 						  "PreHeat=" + self._preHeatPluginImplementationState + " "
 						  "DisplayLayerProgress=" + self._displayLayerProgressPluginImplementationState + " "
-						  "filamentmanager=" + self._filamentManagerPluginImplementationState + " "
-						  "ultimakerformat=" + self._ultimakerFormatPluginImplementationState + " "
-						  "PrusaSlicerThumbnails=" + self._ultimakerFormatPluginImplementationState)
+						  "filamentmanager=" + self._filamentManagerPluginImplementationState)
 
 		if sendToClient == True:
 			missingMessage = ""
@@ -128,12 +114,6 @@ class PrintJobHistoryPlugin(
 
 			if self._displayLayerProgressPluginImplementation == None:
 				missingMessage = missingMessage + "<li>DisplayLayerProgress (<b>" + self._displayLayerProgressPluginImplementationState + "</b>)</li>"
-
-			if self._ultimakerFormatPluginImplementation == None:
-				missingMessage = missingMessage + "<li>UltimakerFormatPackage (<b>" + self._ultimakerFormatPluginImplementationState + "</b>)</li>"
-
-			if self._prusaSlicerThumbnailsPluginImplementation == None:
-				missingMessage = missingMessage + "<li>PrusaSlicerThumbnails (<b>" + self._prusaSlicerThumbnailsPluginImplementationState + "</b>)</li>"
 
 			if missingMessage != "":
 				missingMessage = "<ul>" + missingMessage + "</ul>"
@@ -339,19 +319,15 @@ class PrintJobHistoryPlugin(
 														self._sendErrorMessageToClient
 													 )
 
-			if self._settings.get_boolean([SettingsKeys.SETTINGS_KEY_TAKE_ULTIMAKER_THUMBNAIL_AFTER_PRINT]):
+			if self._settings.get_boolean([SettingsKeys.SETTINGS_KEY_TAKE_PLUGIN_THUMBNAIL_AFTER_PRINT]):
+				metadata = self._file_manager.get_metadata(payload["origin"], payload["path"])
 				# check if available
-				if (not self._ultimakerFormatPluginImplementation == None):
-					self._cameraManager.takeUltimakerPackageThumbnailAsync(CameraManager.buildSnapshotFilename(self._currentPrintJobModel.printStartDateTime), self._currentPrintJobModel.fileName)
+				if ("thumbnail" in metadata):
+					self._cameraManager.takeThumbnailAsync(
+						CameraManager.buildSnapshotFilename(self._currentPrintJobModel.printStartDateTime),
+						metadata["thumbnail"])
 				else:
-					self._logger.warn("UltimakerPackageFormat Thumbnail enabled, but Plugin not available! Activate Plugin-Depenedency check")
-
-			if self._settings.get_boolean([SettingsKeys.SETTINGS_KEY_TAKE_PRUSASLICER_THUMBNAIL_AFTER_PRINT]):
-				# check if available
-				if (not self._prusaSlicerThumbnailsPluginImplementation == None):
-					self._cameraManager.takePrusaSlicerThumbnailAsync(CameraManager.buildSnapshotFilename(self._currentPrintJobModel.printStartDateTime), self._currentPrintJobModel.filePathName)
-				else:
-					self._logger.warn("PrusaSlicerThumbnails enabled, but Plugin not available! Activate Plugin-Depenedency check")
+					self._logger.warn("Thumbnail not found in print metadata")
 
 			# FilamentInformations e.g. length
 			self._createAndAssignFilamentModel(self._currentPrintJobModel, payload)
@@ -493,8 +469,7 @@ class PrintJobHistoryPlugin(
 
 		## Camera
 		settings[SettingsKeys.SETTINGS_KEY_TAKE_SNAPSHOT_AFTER_PRINT] = True
-		settings[SettingsKeys.SETTINGS_KEY_TAKE_ULTIMAKER_THUMBNAIL_AFTER_PRINT] = True
-		settings[SettingsKeys.SETTINGS_KEY_TAKE_PRUSASLICER_THUMBNAIL_AFTER_PRINT] = True
+		settings[SettingsKeys.SETTINGS_KEY_TAKE_PLUGIN_THUMBNAIL_AFTER_PRINT] = True
 
 		## Export / Import
 		settings[SettingsKeys.SETTINGS_KEY_IMPORT_CSV_MODE] = SettingsKeys.KEY_IMPORTCSV_MODE_APPEND

--- a/octoprint_PrintJobHistory/common/SettingsKeys.py
+++ b/octoprint_PrintJobHistory/common/SettingsKeys.py
@@ -19,8 +19,7 @@ class SettingsKeys():
 
 	## Camera
 	SETTINGS_KEY_TAKE_SNAPSHOT_AFTER_PRINT = "takeSnapshotAfterPrint"
-	SETTINGS_KEY_TAKE_ULTIMAKER_THUMBNAIL_AFTER_PRINT = "takeUltimakerThumbnailAfterPrint"
-	SETTINGS_KEY_TAKE_PRUSASLICER_THUMBNAIL_AFTER_PRINT = "takePrusaSlicerThumbnailAfterPrint"
+	SETTINGS_KEY_TAKE_PLUGIN_THUMBNAIL_AFTER_PRINT = "takePluginThumbnailAfterPrint"
 
 	## Export / Import
 	SETTINGS_KEY_IMPORT_CSV_MODE = "importCSVMode"

--- a/octoprint_PrintJobHistory/templates/PrintJobHistory_settings.jinja2
+++ b/octoprint_PrintJobHistory/templates/PrintJobHistory_settings.jinja2
@@ -73,7 +73,7 @@
                 <div class="control-group">
                     <div class="controls">
                         <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: pluginSettings.takePluginThumbnailAfterPrint" > Use thumbnail after print, instead of snapshot (if uploaded in ufp format)
+                            <input type="checkbox" data-bind="checked: pluginSettings.takePluginThumbnailAfterPrint" > Use thumbnail after print, instead of snapshot
                         </label>
                     </div>
                 </div>

--- a/octoprint_PrintJobHistory/templates/PrintJobHistory_settings.jinja2
+++ b/octoprint_PrintJobHistory/templates/PrintJobHistory_settings.jinja2
@@ -73,15 +73,19 @@
                 <div class="control-group">
                     <div class="controls">
                         <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: pluginSettings.takeUltimakerThumbnailAfterPrint" > Use UltimakerPackage thumbnail after print, instead of snapshot (if uploaded in ufp format)
+                            <input type="checkbox" data-bind="checked: pluginSettings.takePluginThumbnailAfterPrint" > Use thumbnail after print, instead of snapshot (if uploaded in ufp format)
                         </label>
                     </div>
                 </div>
                 <div class="control-group">
                     <div class="controls">
-                        <label class="checkbox">
-                            <input type="checkbox" data-bind="checked: pluginSettings.takePrusaSlicerThumbnailAfterPrint" > Use PrusaSlicer thumbnail after print, instead of snapshot
-                        </label>
+                        <div>
+                            Currently tested thumbnail plugins:
+                            <ul>
+                                <li>Ultimaker Format Package (if uploaded in ufp format)</li>
+                                <li>PrusaSlicer Thumbnails </li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Previous solution works fine for prusa slicer and ultimaker, but it was relatng on file names and hardcoded paths. Now the path is generated from print metadata, what means that it can be compatible with other thumbnail plugins. Also, there is no need to check if plugin is installed and no nned to guess source image folder paths. 
Settings again contains only one checkbox for thumbnails.
Idea from issue #28 