### PR TITLE
Fixed importer to look for 'canceled' not 'cancel'

### DIFF
--- a/octoprint_PrintJobHistory/common/CSVExportImporter.py
+++ b/octoprint_PrintJobHistory/common/CSVExportImporter.py
@@ -108,7 +108,7 @@ class PrintStatusCSVFormattorParser:
 			# check if mandatory
 			return
 		SUCCESS = "success"
-		CANCEL = "cancel"
+		CANCEL = "canceled"
 		FAILED = "failed"
 		if (SUCCESS == fieldValue or CANCEL == fieldValue or FAILED == fieldValue):
 			setattr(printJobModel, fieldName, fieldValue)


### PR DESCRIPTION
An exported CVS file would fail to import because it was looking for 'cancel' instead of 'canceled' in the print result field.