### PR TITLE
Always use default tool ID

### DIFF
--- a/octoprint_PrintJobHistory/__init__.py
+++ b/octoprint_PrintJobHistory/__init__.py
@@ -232,11 +232,10 @@ class PrintJobHistoryPlugin(
 		filePath = payload["path"]
 		fileData = self._file_manager.get_metadata(payload["origin"], filePath)
 
-		toolId = None
+		toolId = self._settings.get([SettingsKeys.SETTINGS_KEY_DEFAULT_TOOL_ID])  # "tool0"
 		filamentLength = None
 		if "analysis" in fileData:
 			if "filament" in fileData["analysis"]:
-				toolId = self._settings.get([SettingsKeys.SETTINGS_KEY_DEFAULT_TOOL_ID])  # "tool0"
 				if toolId in fileData["analysis"]["filament"]:
 					filamentLength = fileData["analysis"]["filament"][toolId]['length']
 				else:


### PR DESCRIPTION
The tool ID default was previously only used when analysis was
available which meant that any time the analysis *wasn't* available,
the tool would be left as None causing cascading failures.

Log sample:
```
2020-09-11 07:42:15,150 - octoprint.plugins.PrintJobHistory - INFO - Print result:success, CaptureMode:always
2020-09-11 07:42:15,150 - octoprint.plugins.PrintJobHistory - INFO - Start capturing print job
2020-09-11 07:42:15,155 - octoprint.plugins.PrintJobHistory.SlicerSettingsParser - INFO - Start parsing Slicer-Settings
2020-09-11 07:42:15,360 - octoprint.plugins.PrintJobHistory.SlicerSettingsParser - INFO - Finished parsing Slicer-Settings
2020-09-11 07:42:15,362 - octoprint.plugins.PrintJobHistory - WARNING - Thumbnail not found in print metadata
2020-09-11 07:42:15,370 - octoprint.plugins.PrintJobHistory.CameraManager - INFO - Try taking snapshot '/home/octoprint/.octoprint/data/PrintJobHistory/snapshots/20200910-213751.jpg' from 'http://octoprint.hurd.pvt:5001/?action=snapshot'
2020-09-11 07:42:15,372 - octoprint.plugins.PrintJobHistory - ERROR - MetaFile of 'Dumbo.gcode' doesnt include 'analysis'
2020-09-11 07:42:15,372 - octoprint.plugins.PrintJobHistory - ERROR - Filamentlength not found for toolId 'None'
2020-09-11 07:42:15,373 - octoprint.plugin - ERROR - Error while calling plugin PrintJobHistory
Traceback (most recent call last):
  File "/home/octoprint/OctoPrint/venv/lib/python3.8/site-packages/octoprint/plugin/__init__.py", line 230, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/octoprint/OctoPrint/venv/lib/python3.8/site-packages/octoprint_PrintJobHistory/__init__.py", line 618, in on_event
    self._printJobFinished("success", payload)
  File "/home/octoprint/OctoPrint/venv/lib/python3.8/site-packages/octoprint_PrintJobHistory/__init__.py", line 438, in _printJobFinished
    self._createAndAssignFilamentModel(self._currentPrintJobModel, payload)
  File "/home/octoprint/OctoPrint/venv/lib/python3.8/site-packages/octoprint_PrintJobHistory/__init__.py", line 259, in _createAndAssignFilamentModel
    defaultToolNumber = toolId[-1]
TypeError: 'NoneType' object is not subscriptable
```