### PR TITLE
Fixes #92 - Replace os.rename() with shutil.move()

### DIFF
--- a/octoprint_PrintJobHistory/CameraManager.py
+++ b/octoprint_PrintJobHistory/CameraManager.py
@@ -88,9 +88,9 @@ class CameraManager(object):
 		newFilename = CameraManager.buildSnapshotFilename(newStartDateTime)
 		newFilenameLocation = self.buildSnapshotFilenameLocation(newFilename, False)
 
-		# only rename is source file exists
+		# only rename if source file exists
 		if os.path.isfile(oldFilenameLocation):
-			os.rename(oldFilenameLocation, newFilenameLocation)
+			shutil.move(oldFilenameLocation, newFilenameLocation)
 
 	def deleteSnapshot(self, snapshotFilename):
 		imageLocation= self.buildSnapshotFilenameLocation(snapshotFilename, False)

--- a/octoprint_PrintJobHistory/api/PrintJobHistoryAPI.py
+++ b/octoprint_PrintJobHistory/api/PrintJobHistoryAPI.py
@@ -311,7 +311,7 @@ class PrintJobHistoryAPI(octoprint.plugin.BlueprintPlugin):
 			# file was uploaded
 			sourceLocation = flask.request.values[input_upload_path]
 			targetLocation = self._cameraManager.buildSnapshotFilenameLocation(snapshotFilename, False)
-			os.rename(sourceLocation, targetLocation)
+			shutil.move(sourceLocation, targetLocation)
 			pass
 
 		return flask.jsonify({
@@ -569,5 +569,3 @@ class PrintJobHistoryAPI(octoprint.plugin.BlueprintPlugin):
 		return Response(CSVExportImporter.transform2CSV(allJobsModels),
 						mimetype='text/csv',
 						headers={'Content-Disposition': 'attachment; filename=PrintHistory.csv'})
-
-


### PR DESCRIPTION
This is a fix for #92, which I opened. Two places in the code use [os.rename](https://docs.python.org/3/library/os.html#os.rename), which only works within the boundary of a single filesystem on Linux, and also doesn't work if the paths are symlinks to another filesystem (such as if your ``~/.octoprint`` directory is really a symlink to another mount point).

Replacing the remaining two uses of [os.rename](https://docs.python.org/3/library/os.html#os.rename) with [shutil.move](https://docs.python.org/3/library/shutil.html#shutil.move), which calls os.rename if applicable or performs a copy-and-delete otherwise.