### PR TITLE
Make printjob history snapshots lazy-loading

### DIFF
--- a/octoprint_PrintJobHistory/templates/PrintJobHistory_tab.jinja2
+++ b/octoprint_PrintJobHistory/templates/PrintJobHistory_tab.jinja2
@@ -333,7 +333,7 @@
                 <td data-bind="click: function() { $root.showPrintJobDetailsDialogAction($data); }, visible: $root.tableAttributeVisibility.image">
 <!--                    <img src="http://localhost:5000/plugin/PrintJobHistory/static/images/no-image-icon.png" >-->
 <!--                    <img src="http://localhost:5000/plugin/PrintJobHistory/printJobSnapshot/2019-10-11-15-33" >-->
-                    <img data-bind="attr: {src: $root.snapshotUrl( $data), id: $root.snapshotImageId( $data ) }" >
+                    <img loading=lazy data-bind="attr: {src: $root.snapshotUrl( $data), id: $root.snapshotImageId( $data ) }" >
                 </td>
 <!--                <td>-->
 <!--                    <div class="btn-group action-buttons" >-->


### PR DESCRIPTION
snapshot images are not important from octoprint UI perspective, and should be loaded on demand when needed instead of directly

with the current code, the snapshot images are loaded directly, blocking some of the resources needed to the ui of octoprint working and thus delaying the moment a user can interact with the UI.

with this change the snapshot image is only loaded when need in the view