### PR TITLE
fix compile errors

### DIFF
--- a/octoprint_PrintJobHistory/__init__.py
+++ b/octoprint_PrintJobHistory/__init__.py
@@ -292,11 +292,11 @@ class PrintJobHistoryPlugin(
 
 					filemanentModel.usedWeight = usedWeight
 					filemanentModel.usedCost = spoolCost / spoolWeight * usedWeight
-		else if self._spoolManagerPluginImplementation != None and self._spoolManagerPluginImplementationState == "enabled":
+		elif self._spoolManagerPluginImplementation != None and self._spoolManagerPluginImplementationState == "enabled":
 
 			filemanentModel.usedLength = self._spoolManagerPluginImplementation.filamentOdometer.totalExtrusion[0]
 			selectedSpool = self._spoolManagerPluginImplementation.filamentManager.loadSelectedSpool()
-            toolId = 0 #TODO multi extruder support in SpoolManager
+			toolId = 0 #TODO multi extruder support in SpoolManager
 			if  selectedSpool != None:
 				spoolData = selectedSpool
 				if (spoolData == None):


### PR DESCRIPTION
Hi,
because of the discussion in #119 i looked into the code and found 2 errors.

```
2021-03-08 11:45:18,536 - octoprint.plugin.core - ERROR - Invalid syntax in /home/oskar/projects/3dprinting/OctoPrint-PrintJobHistory/octoprint_PrintJobHistory/__init__.py for plugin PrintJobHistory
Traceback (most recent call last):
  File "/home/oskar/projects/3dprinting/OctoPrint/src/octoprint/plugin/core.py", line 762, in _parse_metadata
    root = ast.parse(f.read(), filename=path)
  File "/usr/lib/python3.6/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "/home/oskar/projects/3dprinting/OctoPrint-PrintJobHistory/octoprint_PrintJobHistory/__init__.py", line 295
    else if self._spoolManagerPluginImplementation != None and self._spoolManagerPluginImplementationState == "enabled":
          ^
SyntaxError: invalid syntax
```
```
2021-03-08 11:46:25,871 - octoprint.plugin.core - ERROR - Invalid syntax in /home/oskar/projects/3dprinting/OctoPrint-PrintJobHistory/octoprint_PrintJobHistory/__init__.py for plugin PrintJobHistory
Traceback (most recent call last):
  File "/home/oskar/projects/3dprinting/OctoPrint/src/octoprint/plugin/core.py", line 762, in _parse_metadata
    root = ast.parse(f.read(), filename=path)
  File "/usr/lib/python3.6/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "/home/oskar/projects/3dprinting/OctoPrint-PrintJobHistory/octoprint_PrintJobHistory/__init__.py", line 299
    toolId = 0 #TODO multi extruder support in SpoolManager
                                                          ^
IndentationError: unindent does not match any outer indentation level
```
