### PR TITLE
Rename a reference of filamentOdometer to myFilamentOdmeter to reflect changes under other projects commit

### DIFF
--- a/octoprint_PrintJobHistory/__init__.py
+++ b/octoprint_PrintJobHistory/__init__.py
@@ -251,7 +251,7 @@ class PrintJobHistoryPlugin(
 
 		if self._filamentManagerPluginImplementation != None and self._filamentManagerPluginImplementationState == "enabled":
 
-			filemanentModel.usedLength = self._filamentManagerPluginImplementation.filamentOdometer.totalExtrusion[0]
+			filemanentModel.usedLength = self._filamentManagerPluginImplementation.myFilamentOdometer.totalExtrusion[0]
 			selectedSpools = self._filamentManagerPluginImplementation.filamentManager.get_all_selections(self._filamentManagerPluginImplementation.client_id)
 			if  selectedSpools != None and len(selectedSpools) > 0:
 				spoolData = None


### PR DESCRIPTION
Rename a reference of filamentOdometer to myFilamentOdmeter to reflect changes under other projects commit

https://github.com/OllisGit/OctoPrint-FilamentManager/commit/5237c4dc48f9eba0f26d50c042a938649ecc7bf9

With out this no jobs would save wit the following error:

    2021-03-08 17:37:24,595 - octoprint.plugin - ERROR - Error while calling plugin PrintJobHistory
    Traceback (most recent call last):
      File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint/plugin/__init__.py", line 271, in call_plugin
        result = getattr(plugin, method)(*args, **kwargs)
      File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint/util/__init__.py", line 1890, in wrapper
        return f(*args, **kwargs)
      File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_PrintJobHistory/__init__.py", line 614, in on_event
        self._printJobFinished("success", payload)
      File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_PrintJobHistory/__init__.py", line 436, in _printJobFinished
        self._createAndAssignFilamentModel(self._currentPrintJobModel, payload)
      File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_PrintJobHistory/__init__.py", line 254, in _createAndAssignFilamentModel
        filemanentModel.usedLength = self._filamentManagerPluginImplementation.filamentOdometer.totalExtrusion[0]
    AttributeError: 'FilamentManagerPlugin' object has no attribute 'filamentOdometer'