### PR TITLE
fix double counting bug in statistics overview

### DIFF
--- a/octoprint_PrintJobHistory/DatabaseManager.py
+++ b/octoprint_PrintJobHistory/DatabaseManager.py
@@ -555,6 +555,10 @@ class DatabaseManager(object):
 			allFilaments = job.getFilamentModels()
 			if allFilaments != None:
 				for filla in allFilaments:
+					if filla.toolId == "total":
+						# exclude totals, otherwise everything is counted twice
+						continue
+
 					if (StringUtils.isEmpty(filla.usedLength) == False):
 						length = length + filla.usedLength
 					if (StringUtils.isEmpty(filla.usedWeight) == False):


### PR DESCRIPTION
This fixes a bug in the statistic calculation where filament length,
weight and some other entries were doubled.
As already assumed by donlook in #161 this is due to the existence of
print job entries for every tool and a total entry. This simple fix
simply skips the total entries, only including the ones per tool.

Fixes #161