### PR TITLE
Update PrintJobHistoryAPI.py to fix GET of thumbnails that broke arou…

### DIFF
--- a/octoprint_PrintJobHistory/api/PrintJobHistoryAPI.py
+++ b/octoprint_PrintJobHistory/api/PrintJobHistoryAPI.py
@@ -440,7 +440,7 @@ class PrintJobHistoryAPI(octoprint.plugin.BlueprintPlugin):
 	@octoprint.plugin.BlueprintPlugin.route("/printJobSnapshot/<string:snapshotFilename>", methods=["GET"])
 	def get_snapshot(self, snapshotFilename):
 		absoluteFilename = self._cameraManager.buildSnapshotFilenameLocation(snapshotFilename)
-		return send_file(absoluteFilename, mimetype='image/jpg', cache_timeout=1)
+		return send_file(absoluteFilename, mimetype='image/jpg', max_age=86400)
 
 	#######################################################################################   TAKE SNAPSHOT
 	@octoprint.plugin.BlueprintPlugin.route("/takeSnapshot/<string:snapshotFilename>", methods=["PUT"])


### PR DESCRIPTION
…nd Octoprint 1.9 timeframe

removed outdated cache_timeout and replaced with max_age, set to 1 day (86400 seconds) but whatever makes sense is good there if you wanted to change it.