### PR TITLE
Allowing for spaces and other characters in gcode filenames so thumbnails can be found

### DIFF
--- a/octoprint_PrintJobHistory/CameraManager.py
+++ b/octoprint_PrintJobHistory/CameraManager.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from __future__ import absolute_import
+import urllib.parse
 
 import shutil
 import threading
@@ -244,7 +245,10 @@ class CameraManager(object):
 
 		pluginFolder = splitPath[1]
 		thumbnailName = splitPath[3]
-
+		
+		# account for encoded filenames from the metadata
+		thumbnailName = urllib.parse.unquote( thumbnailName )
+		
 		thumbnailLocation = self._pluginDataBaseFolder + "/../" + pluginFolder + "/" + thumbnailName
 
 		if os.path.isfile(thumbnailLocation):

--- a/octoprint_PrintJobHistory/api/PrintJobHistoryAPI.py
+++ b/octoprint_PrintJobHistory/api/PrintJobHistoryAPI.py
@@ -440,7 +440,7 @@ class PrintJobHistoryAPI(octoprint.plugin.BlueprintPlugin):
 	@octoprint.plugin.BlueprintPlugin.route("/printJobSnapshot/<string:snapshotFilename>", methods=["GET"])
 	def get_snapshot(self, snapshotFilename):
 		absoluteFilename = self._cameraManager.buildSnapshotFilenameLocation(snapshotFilename)
-		return send_file(absoluteFilename, mimetype='image/jpg', cache_timeout=1)
+		return send_file(absoluteFilename, mimetype='image/jpg', max_age=86400)
 
 	#######################################################################################   TAKE SNAPSHOT
 	@octoprint.plugin.BlueprintPlugin.route("/takeSnapshot/<string:snapshotFilename>", methods=["PUT"])


### PR DESCRIPTION
the metadata is returning thumbnail filenames encoded to handle non-standard filename characters like spaces, etc. the change in CameraManager will now handle that when looking for thumbnails. (the other change is the previous PR around cache syntax that was breaking thumbnails after an octoprint update)

For anyone reading this that wants to apply these changes, look at the changes in this commit in CameraManager.py.

- Edit `~/oprint/lib/python3.9/site-packages/octoprint_PrintJobHistory/CameraManager.py` (your python folder version may differ, i only tested on python3. python2 may differ)
- add `import urllib.parse` at the top of the file
- add `		thumbnailName = urllib.parse.unquote( thumbnailName )` around line 250, below `thumbnailName = splitPath[3]` (be mindful to match the tabbing, copy the mentioned line above it if needed)
- restart octoprint

That should do it going forward. Previous jobs will not be resolved. 

Hopefully someday OctoPrint or @OllisGit do something about this very useful plugin so these updates get to everyone.

If you still see errors with the thumbnails, open the print history job and click the Technical Log link (above the thumbnail area) and paste it in a ticket here and feel free to @ me if you want me to look at it.